### PR TITLE
Add client_cert parameter to DevpiClient and DevpiCommandWrapper

### DIFF
--- a/devpi_plumber/client.py
+++ b/devpi_plumber/client.py
@@ -48,13 +48,18 @@ class DevpiCommandWrapper(object):
         parts = urlsplit(url)
         return urlunsplit((parts.scheme, parts.netloc, '', '', ''))
 
-    def _execute(self, *args, **kwargs):
-        kwargs = OrderedDict(kwargs)
+    def _create_command(self, *args, **kwargs):
+        # sort to make deterministic for tests
+        kwargs = OrderedDict(sorted(kwargs.items(), key=lambda t: t[0]))
         kwargs.update({'--clientdir': self._client_dir})
         if args[0] == 'use' and self._client_cert:
             kwargs.update({'--client-cert': self._client_cert})
 
-        args = ['devpi'] + list(args) + ['{}={}'.format(k, v) for k, v in iteritems(kwargs)]
+        return ['devpi'] + list(args) + ['{}={}'.format(k, v)
+                                         for k, v in iteritems(kwargs)]
+
+    def _execute(self, *args, **kwargs):
+        args = self._create_command(*args, **kwargs)
 
         with mutable_sys():
             sys.stdout = sys.stderr = output = StringIO()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,8 @@ import requests
 from twitter.common.contextutil import pushd
 from unittest import TestCase
 
-from devpi_plumber.client import DevpiClientError, volatile_index
+from devpi_plumber.client import (DevpiClientError, DevpiCommandWrapper,
+                                  volatile_index)
 from devpi_plumber.server import TestServer
 
 
@@ -228,3 +229,87 @@ class VolatileIndexTests(TestCase):
                 with volatile_index(client, 'user/index', force_volatile=False):
                     pass
             self.assertIn('volatile=False', client.modify_index(index))
+
+
+class DevpiCommandWrapperTest(TestCase):
+    def setUp(self):
+        # monkey patch DevpiCommandWrapper _execute just returns the command
+        # that would be executed.
+        def _echo_execute(*args, **kwargs):
+            return DevpiCommandWrapper._create_command(*args, **kwargs)
+
+        self._original_execute = DevpiCommandWrapper._execute
+        DevpiCommandWrapper._execute = _echo_execute
+
+    def tearDown(self):
+        # undo monkey patch
+        DevpiCommandWrapper._execute = self._original_execute
+
+    def test_use(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example')
+        self.assertEqual(
+            dcw.use('hans/prod'),
+            ['devpi', 'use', 'http://localhost/hans/prod',
+             '--clientdir=/example'])
+
+    def test_use_client_cert(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example',
+                                  client_cert='/path/to/cert')
+        self.assertEqual(
+            dcw.use('hans/prod'),
+            ['devpi', 'use', 'http://localhost/hans/prod',
+             '--clientdir=/example', '--client-cert=/path/to/cert'])
+
+    def test_login(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example')
+        self.assertEqual(
+            dcw.login('hans', 'secret'),
+            ['devpi', 'login', 'hans', '--password',
+             'secret', '--clientdir=/example'])
+
+    def test_logoff(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example')
+        self.assertEqual(dcw.logoff(),
+                         ['devpi', 'logoff', '--clientdir=/example'])
+
+    def test_create_user(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example')
+        self.assertEqual(
+            dcw.create_user('hans', bar='baz'),
+            ['devpi', 'user', '--create', 'hans',
+             'bar=baz', '--clientdir=/example'])
+
+    def test_modify_user(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example')
+        self.assertEqual(
+            dcw.modify_user('hans', foo='bar'),
+            ['devpi', 'user', '--modify', 'hans',
+             'foo=bar', '--clientdir=/example'])
+
+    def test_create_index(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example')
+        self.assertEqual(
+            dcw.create_index('myindex', bases='/emilie/prod', volatile=False),
+            ['devpi', 'index', '--create', 'myindex', 'bases=/emilie/prod',
+             'volatile=False', '--clientdir=/example'])
+
+    def test_upload(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example')
+        self.assertEqual(
+            dcw.upload('/foo/bar/', directory=True),
+            ['devpi', 'upload', '--from-dir',
+             '/foo/bar/', '--clientdir=/example'])
+        self.assertEqual(
+            dcw.upload('/foo/bar/', dry_run=True),
+            ['devpi', 'upload', '--dry-run',
+             '/foo/bar/', '--clientdir=/example'])
+        self.assertEqual(
+            dcw.upload('/foo/bar/', with_docs=True),
+            ['devpi', 'upload', '--with-docs',
+             '/foo/bar/', '--clientdir=/example'])
+
+    def test_remove(self):
+        dcw = DevpiCommandWrapper('http://localhost/', '/example')
+        self.assertEqual(
+            dcw.remove('foobar'),
+            ['devpi', 'remove', '-y', 'foobar', '--clientdir=/example'])


### PR DESCRIPTION
This adds support for the devpi client's --client-cert parameter so that an SSL certificate may be used to authenticate with the server.