### PR TITLE
Add support for `devpi getjson`

### DIFF
--- a/devpi_plumber/client.py
+++ b/devpi_plumber/client.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 import logging
 import re
 import sys
@@ -131,6 +132,9 @@ class DevpiCommandWrapper(object):
 
     def remove(self, *args):
         return self._execute('remove', '-y', *args)
+
+    def get_json(self, path):
+        return json.loads(self._execute('getjson', path))
 
     @property
     def server_url(self):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as f:
 
 setup(
     name='devpi-plumber',
-    version='0.2.14',
+    version='0.2.15',
     packages=find_packages(exclude=['tests']),
     author='Stephan Erb',
     author_email='stephan.erb@blue-yonder.com',


### PR DESCRIPTION
Documentation is shown in `devpi list`. Thus, to support querying information on documentation the JSON has to be available.