### PR TITLE
Bugfix/server 4.3.0 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 UNRELEASED
 ----------
 
+- Fix compatibility with devpi-server 4.3.0 and up.
 - The new environment variables ``DEVPI_PLUMBER_SERVER_HOST`` and ``DEVPI_PLUMBER_SERVER_PORT`` allow you to tune where
   the test server binds to from the outside.
 

--- a/devpi_plumber/server.py
+++ b/devpi_plumber/server.py
@@ -114,7 +114,7 @@ def wait_for_startup(server, url):
         if server.poll() is not None:
             raise Exception('Server failed to start up.')
         try:
-            requests.get(url, timeout=0.1)
+            requests.get(url, timeout=1)
         except requests.RequestException:
             time.sleep(0.1)  # Request failed, try again
         else:

--- a/devpi_plumber/server.py
+++ b/devpi_plumber/server.py
@@ -68,12 +68,13 @@ def _assert_no_logged_errors(fail_on_output, logfile):
 def DevpiServer(options):
     url = 'http://localhost:{}'.format(options['port'])
     server = None
-    stdout = open(options['serverdir'] + '/server.log', 'wb') if 'serverdir' in options else subprocess.DEVNULL
-    try:
+    logfile = options['serverdir'] + '/server.log' if 'serverdir' in options else os.devnull
+    with open(logfile, 'wb') as stdout:
         try:
             server = subprocess.Popen(
                 build_devpi_server_command(**options),
-                stderr=subprocess.STDOUT, stdout=stdout, stdin=subprocess.DEVNULL,
+                stderr=subprocess.STDOUT,
+                stdout=stdout,
             )
             wait_for_startup(server, url)
             yield url
@@ -85,9 +86,6 @@ def DevpiServer(options):
                 except TimeoutError:
                     server.kill()
                     server.wait(30)
-    finally:
-        if stdout is not subprocess.DEVNULL:
-            stdout.close()
 
 
 def build_devpi_server_command(**options):

--- a/devpi_plumber/server.py
+++ b/devpi_plumber/server.py
@@ -69,7 +69,7 @@ def DevpiServer(options):
     url = 'http://localhost:{}'.format(options['port'])
     server = None
     logfile = options['serverdir'] + '/server.log' if 'serverdir' in options else os.devnull
-    with open(logfile, 'wb') as stdout:
+    with open(logfile, 'wb', buffering=0) as stdout:
         try:
             server = subprocess.Popen(
                 build_devpi_server_command(**options),


### PR DESCRIPTION
In devpi-server 4.3.0 the `--stop` functionality is broken and 4.3.1 deprecates `--start`, `--status` and `--stop`. This change implements our own logic to run the devpi server in a background process so that we do not longer have to rely on the built-in functionality.

This should unblock us from updating the Devpi server versions used in the acceptance tests as well as in the tests of Brandon and friends.