### PR TITLE
Restrict test to run on IPv4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
 - '3.3'
 - '3.4'
 - '3.5'
+env:
+- DEVPI_PLUMBER_SERVER_HOST=127.0.0.1
 sudo: false
 install:
 - pip install -r requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+UNRELEASED
+----------
+
+- The new environment variables ``DEVPI_PLUMBER_SERVER_HOST`` and ``DEVPI_PLUMBER_SERVER_PORT`` allow you to tune where
+  the test server binds to from the outside.
+
 0.4.2
 -----
 - Don't cache servers started with `--no-root-pypi`.

--- a/devpi_plumber/server.py
+++ b/devpi_plumber/server.py
@@ -17,8 +17,10 @@ def TestServer(users={}, indices={}, config={}, fail_on_output=['Traceback']):
     with temporary_dir() as server_dir:
 
         server_options = {
-            'port': 2414,
-            'serverdir': server_dir}
+            'host': os.getenv('DEVPI_PLUMBER_SERVER_HOST', 'localhost'),
+            'port': os.getenv('DEVPI_PLUMBER_SERVER_PORT', 2414),
+            'serverdir': server_dir,
+        }
         server_options.update(config)
 
         initialize_serverdir(server_options)


### PR DESCRIPTION
Seems for some reason binding to IPv6 addresses fails on Travis.