### PR TITLE
Logoff devpi user if using DevpiClient before deleting the tmp directory

### DIFF
--- a/devpi_plumber/client.py
+++ b/devpi_plumber/client.py
@@ -35,6 +35,9 @@ def DevpiClient(url, user=None, password=None, client_cert=None):
 
         yield wrapper
 
+        if user and password is not None:
+            wrapper.logoff()
+
 
 class DevpiCommandWrapper(object):
 


### PR DESCRIPTION
When using DevpiClient, the client never issued a logoff command.

I tried hard to think about a test which would ensure that this does not regress, however without a lot of stubbing/mocking I did not find a solution.
This is why the PR does not include a test.