### PR TITLE
Provide compatibility with Devpi Server version 6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 UNRELEASED
 ----------
 
+- Verify functionality against Devpi 6.
 - Add official support for Python 3.7 to 3.9.
 - Drop support for Python 2.7 and 3.5.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 UNRELEASED
 ----------
 
-- Verify functionality against Devpi 6.
+- Establish compatibility with Devpi Server 6. Compatibility with Devpi Server < 5.2.0 is dropped for this.
 - Add official support for Python 3.7 to 3.9.
 - Drop support for Python 2.7 and 3.5.
 

--- a/devpi_plumber/server.py
+++ b/devpi_plumber/server.py
@@ -27,6 +27,8 @@ def TestServer(users={}, indices={}, config={}, fail_on_output=['Traceback']):
 
         initialize_serverdir(server_options)
 
+        server_options.pop('no-root-pypi', None)  # This is only relevant for initialisation
+
         with DevpiServer(server_options) as url:
             with DevpiClient(url, 'root', '') as client:
 

--- a/devpi_plumber/server.py
+++ b/devpi_plumber/server.py
@@ -42,7 +42,6 @@ def TestServer(users={}, indices={}, config={}, fail_on_output=['Traceback']):
 
 
 def import_state(serverdir, importdir):
-    devpi_command('init', serverdir=serverdir)
     devpi_command('import', importdir, serverdir=serverdir, **{'no-events': None})
 
 

--- a/devpi_plumber/server.py
+++ b/devpi_plumber/server.py
@@ -143,8 +143,8 @@ def initialize_serverdir(server_options):
     """
     def init_serverdir():
         cleaned_options = server_options.copy()
-        del cleaned_options['host']
-        del cleaned_options['port']
+        for option in ('host', 'port', 'secretfile'):
+            cleaned_options.pop(option, None)
         devpi_command('init', **cleaned_options)
 
     serverdir_new = server_options['serverdir']

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,69 +6,71 @@
 #
 alabaster==0.7.12
     # via sphinx
-apipkg==1.5
-    # via execnet
 appdirs==1.4.4
+    # via devpi-server
+argon2-cffi==20.1.0
     # via
     #   devpi-server
-    #   virtualenv
-argon2-cffi==20.1.0
-    # via passlib
-attrs==20.3.0
+    #   passlib
+attrs==21.2.0
     # via
     #   devpi-server
     #   pytest
 babel==2.9.1
     # via sphinx
-build==0.3.1.post1
+backports.entry-points-selectable==1.1.0
+    # via virtualenv
+build==0.5.1
     # via check-manifest
-certifi==2020.12.5
+certifi==2021.5.30
     # via requests
-cffi==1.14.5
+cffi==1.14.6
     # via argon2-cffi
-chardet==4.0.0
+charset-normalizer==2.0.3
     # via requests
 check-manifest==0.46
     # via devpi-client
 coverage==5.5
     # via pytest-cov
+defusedxml==0.7.1
+    # via devpi-server
 devpi-client==5.2.2
-    # via sanitized-package
+    # via devpi-plumber
 devpi-common==3.6.0
     # via
     #   devpi-client
     #   devpi-server
-devpi-server==5.5.1
-    # via sanitized-package
-distlib==0.3.1
+devpi-server==6.1.0
+    # via devpi-plumber
+distlib==0.3.2
     # via virtualenv
-docutils==0.16
+docutils==0.17.1
     # via sphinx
-execnet==1.8.0
+execnet==1.9.0
     # via devpi-server
 filelock==3.0.12
     # via
     #   tox
     #   virtualenv
-hupper==1.10.2
+hupper==1.10.3
     # via pyramid
-idna==2.10
+idna==3.2
     # via requests
 imagesize==1.2.0
     # via sphinx
 iniconfig==1.1.1
     # via pytest
-itsdangerous==1.1.0
+itsdangerous==2.0.1
     # via devpi-server
-jinja2==2.11.3
+jinja2==3.0.1
     # via sphinx
 lazy==1.4
     # via devpi-common
-markupsafe==1.1.1
+markupsafe==2.0.1
     # via jinja2
 mock==4.0.3
     # via -r requirements.in
-packaging==20.9
+packaging==21.0
     # via
     #   build
     #   pytest
@@ -78,9 +80,9 @@ passlib[argon2]==1.7.4
     # via devpi-server
 pastedeploy==2.1.1
     # via plaster-pastedeploy
-pep517==0.10.0
+pep517==0.11.0
     # via build
-pkginfo==1.7.0
+pkginfo==1.7.1
     # via devpi-client
 plaster-pastedeploy==0.7
     # via pyramid
@@ -88,6 +90,8 @@ plaster==1.0
     # via
     #   plaster-pastedeploy
     #   pyramid
+platformdirs==2.1.0
+    # via virtualenv
 pluggy==0.13.1
     # via
     #   devpi-client
@@ -103,36 +107,36 @@ py==1.10.0
     #   tox
 pycparser==2.20
     # via cffi
-pygments==2.8.1
+pygments==2.9.0
     # via sphinx
 pyparsing==2.4.7
     # via packaging
-pyramid==1.10.8
+pyramid==2.0
     # via devpi-server
-pytest-cov==2.11.1
+pytest-cov==2.12.1
     # via -r requirements.in
-pytest==6.2.2
+pytest==6.2.4
     # via
     #   -r requirements.in
     #   pytest-cov
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via strictyaml
 pytz==2021.1
     # via babel
 repoze.lru==0.7
     # via devpi-server
-requests==2.25.1
+requests==2.26.0
     # via
     #   devpi-common
-    #   sanitized-package
+    #   devpi-plumber
     #   sphinx
-ruamel.yaml.clib==0.2.2
+ruamel.yaml.clib==0.2.6
     # via ruamel.yaml
-ruamel.yaml==0.17.0
-    # via strictyaml
+ruamel.yaml==0.17.10
+    # via devpi-server
 setuptools-scm==6.0.1
     # via -r requirements.in
-six==1.15.0
+six==1.16.0
     # via
     #   argon2-cffi
     #   python-dateutil
@@ -140,44 +144,46 @@ six==1.15.0
     #   virtualenv
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==3.5.3
+sphinx==4.1.1
     # via -r requirements.in
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx
-sphinxcontrib-htmlhelp==1.0.3
+sphinxcontrib-htmlhelp==2.0.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.4
+sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-strictyaml==1.3.2
+strictyaml==1.4.4
     # via devpi-server
 toml==0.10.2
     # via
     #   build
     #   check-manifest
-    #   pep517
     #   pytest
+    #   pytest-cov
     #   tox
-tox==3.23.0
+tomli==1.1.0
+    # via pep517
+tox==3.24.0
     # via devpi-client
 translationstring==1.4
     # via pyramid
-twitter-common-contextutil==0.3.11
-    # via sanitized-package
+twitter.common.contextutil==0.3.11
+    # via devpi-plumber
 twitter.common.dirutil==0.3.11
-    # via twitter-common-contextutil
+    # via twitter.common.contextutil
 twitter.common.lang==0.3.11
     # via twitter.common.dirutil
-urllib3==1.26.5
+urllib3==1.26.6
     # via requests
 venusian==3.0.0
     # via pyramid
-virtualenv==20.4.3
+virtualenv==20.6.0
     # via tox
 waitress==2.0.0
     # via devpi-server
@@ -185,7 +191,7 @@ webob==1.8.7
     # via pyramid
 zope.deprecation==4.4.0
     # via pyramid
-zope.interface==5.3.0
+zope.interface==5.4.0
     # via pyramid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'twitter.common.contextutil',
     ],
     extras_require={
-        'test': ['devpi-server>=4.2.1'],
+        'test': ['devpi-server>=5.2.0'],
     },
     tests_require=[
         'mock',


### PR DESCRIPTION
This solves the compatibility issues with version 6 of the Devpi Server reported in issue #63 .

Keeping this as a draft for now as I'd prefer to first get #64 merged and having this PR rebased onto that so that this has not only been tested on my local working copy.