### PR TITLE
Publish via trusted publisher instead of PyPI API Token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/devpi-plumber
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python
@@ -21,6 +26,3 @@ jobs:
       run: python -m build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Upload Release ot PyPI
+name: Upload Release to PyPI
 
 on:
   release:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -16,7 +16,9 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -1,0 +1,33 @@
+---
+
+name: "Publish latest default branch content to TestPyPI"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish-to-stage:
+    runs-on: ubuntu-latest
+    environment:
+      name: stage-release
+      url: https://test.pypi.org/p/devpi-plumber
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -26,7 +26,12 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install build
       - name: Build package
-        run: python -m build
+        run:
+          # Published packages must not have a local version. As we know that we are pushing from the main
+          # branch, the difference from the last tag is already unique anyhow. Thus, we can just skip it.
+          export SETUPTOOLS_SCM_OVERRIDES_FOR_DEVPI_PLUMBER='{ local_scheme = "no-local-version" }'
+          
+          python -m build
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
This switches the publication method to using [a trusted publisher](https://docs.pypi.org/trusted-publishers/).

In addition, and primarily to verify that we properly understood how to use a trusted publisher, any commits pushed to the main branch, i.e. via merging a PR, will now also trigger a dev release being pushed to [TestPyPI](https://test.pypi.org/).