### PR TITLE
Verify support for Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,12 +23,19 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements.txt
-        python -m pip install coveralls
+        if [ "${{ matrix.python-version }}" != "3.13" ]; then  # workaround for TheKevJames/coveralls-python#523
+          python -m pip install coveralls
+        fi
         python -m pip freeze
     - name: Test with pytest
       run: |
-        pytest
+        if [ "${{ matrix.python-version }}" == "3.13" ]; then
+          pytest --no-cov  # workaround for TheKevJames/coveralls-python#523
+        else
+          pytest
+        fi
     - name: Upload coverage data
+      if: matrix.python-version != '3.13'  # workaround for TheKevJames/coveralls-python#523
       run: |
         coveralls --service=github
       env:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Unreleased
 ----------
 
-- Add official support for Python 3.12.
+- Add official support for Python 3.12 and 3.13.
 - Drop support for Python 3.8.
 
 0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 alabaster==0.7.16
     # via sphinx
-anyio==4.6.0
+anyio==4.8.0
     # via httpx
 argon2-cffi==23.1.0
     # via
@@ -14,36 +14,36 @@ argon2-cffi==23.1.0
     #   passlib
 argon2-cffi-bindings==21.2.0
     # via argon2-cffi
-attrs==24.2.0
+attrs==25.1.0
     # via devpi-server
-babel==2.16.0
+babel==2.17.0
     # via sphinx
 build==1.2.2.post1
     # via
     #   check-manifest
     #   devpi-client
-certifi==2024.8.30
+certifi==2025.1.31
     # via
     #   httpcore
     #   httpx
     #   requests
 cffi==1.17.1
     # via argon2-cffi-bindings
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 check-manifest==0.50
     # via devpi-client
-coverage==7.6.2
+coverage==7.6.12
     # via pytest-cov
 defusedxml==0.7.1
     # via devpi-server
-devpi-client==7.1.0
+devpi-client==7.2.0
     # via -r core-requirements.txt
 devpi-common==4.0.4
     # via
     #   devpi-client
     #   devpi-server
-devpi-server==6.13.0
+devpi-server==6.14.0
     # via -r extra-test-requirements.txt
 docutils==0.21.2
     # via sphinx
@@ -53,9 +53,9 @@ exceptiongroup==1.2.2
     #   pytest
 h11==0.14.0
     # via httpcore
-httpcore==1.0.6
+httpcore==1.0.7
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via devpi-server
 hupper==1.12.1
     # via pyramid
@@ -66,7 +66,7 @@ idna==3.10
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via
     #   build
     #   sphinx
@@ -82,11 +82,11 @@ lazy==1.6
     # via
     #   devpi-common
     #   devpi-server
-markupsafe==3.0.1
+markupsafe==3.0.2
     # via jinja2
 mock==5.1.0
     # via -r requirements.in
-packaging==24.1
+packaging==24.2
     # via
     #   build
     #   packaging-legacy
@@ -99,7 +99,7 @@ passlib==1.7.4
     # via devpi-server
 pastedeploy==3.1.0
     # via plaster-pastedeploy
-pkginfo==1.11.2
+pkginfo==1.12.1.2
     # via devpi-client
 plaster==1.1.2
     # via
@@ -120,17 +120,17 @@ py==1.11.0
     # via devpi-server
 pycparser==2.22
     # via cffi
-pygments==2.18.0
+pygments==2.19.1
     # via sphinx
 pyproject-hooks==1.2.0
     # via build
 pyramid==2.0.2
     # via devpi-server
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   -r requirements.in
     #   pytest-cov
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via strictyaml
@@ -141,18 +141,16 @@ requests==2.32.3
     #   -r core-requirements.txt
     #   devpi-common
     #   sphinx
-ruamel-yaml==0.18.6
+ruamel-yaml==0.18.10
     # via devpi-server
-ruamel-yaml-clib==0.2.8
+ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
 setuptools-scm==8.1.0
     # via -r requirements.in
-six==1.16.0
+six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==7.4.7
@@ -171,7 +169,7 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 strictyaml==1.7.3
     # via devpi-server
-tomli==2.0.2
+tomli==2.2.1
     # via
     #   build
     #   check-manifest
@@ -192,19 +190,19 @@ typing-extensions==4.12.2
     # via
     #   anyio
     #   setuptools-scm
-urllib3==2.2.3
+urllib3==2.3.0
     # via requests
-venusian==3.1.0
+venusian==3.1.1
     # via pyramid
-waitress==3.0.1
+waitress==3.0.2
     # via devpi-server
-webob==1.8.8
+webob==1.8.9
     # via pyramid
-zipp==3.20.2
+zipp==3.21.0
     # via importlib-metadata
-zope-deprecation==5.0
+zope-deprecation==5.1
     # via pyramid
-zope-interface==7.1.0
+zope-interface==7.2
     # via pyramid
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,6 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
     ],
 )


### PR DESCRIPTION
This adds testing on Python 3.13. Due to TheKevJames/coveralls-python#523 we have to exclude Python 3.13 from our coverage checks, though.